### PR TITLE
Fix: Ignore all branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   default:
     docker:
-      - image: circleci/golang:1.16.1
+      - image: circleci/golang:1.15.11
     working_directory: /go/src/github.com/mattermost/rotatorctl
 
 jobs:
@@ -47,5 +47,7 @@ workflows:
       jobs:
         - release:
             filters:
+              branches:
+                ignore: /.*/
               tags:
                 only: /v[0-9]+(\.[0-9]+)*/


### PR DESCRIPTION

#### Summary
Run release only on tag pushes.
Downgrade golang to circle to 1.15.11 instead of 1.16.1 trying to fix go mod errors

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34456

#### Release Note

```release-note
Fix: Avoid release pipeline to run on every commit.
```