### PR TITLE
Fix: Dependency failure with go 1.15.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   default:
     docker:
-      - image: circleci/golang:1.15.11
+      - image: circleci/golang:1.16.3
     working_directory: /go/src/github.com/mattermost/rotatorctl
 
 jobs:


### PR DESCRIPTION
#### Summary
Fix: Dependency failure with go 1.15.11

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/rotatorctl/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note

```release-note
Fix: Dependency failure with go 1.15.11

```