### PR TITLE
Fix: Pre-create directory needed on release

### DIFF
--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -1,5 +1,7 @@
+#! /bin/bash
+
 # Usage: sh notify.sh
-#!/bin/bash
+
 REPO=$(echo $GITHUB_CONTEXT | jq -r '.repository')
 TAGVERSION=$(echo $GITHUB_CONTEXT | jq -r '.event.release.tag_name')
 TAGURL=$(echo $GITHUB_CONTEXT | jq -r '.event.release.html_url')

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,11 +1,13 @@
+#! /bin/bash
+
 # Usage: sh release.sh
 # Note: To run this script locally you need to export environment variables CIRCLE_TAG and GITHUB_TOKEN.
-#!/bin/bash
+
 FUTURE_RELEASE_SHA=$(hub rev-parse HEAD)
 LATEST_RELEASE=$(hub release)
 LATEST_RELEASE_SHA=$(hub rev-parse ${LATEST_RELEASE})
 LATEST_RELEASE_NEXT_COMMIT_SHA=$(hub log ${LATEST_RELEASE}..HEAD --oneline --pretty=%H | tail -n1)
-
+mkdir -p ./build/_output/docs/
 release-notes --org mattermost --repo rotatorctl --start-sha $LATEST_RELEASE_NEXT_COMMIT_SHA --end-sha $FUTURE_RELEASE_SHA  --output ./build/_output/docs/relnote.md --required-author "" --branch main
 
 cat ./build/_output/docs/relnote.md | sed '/docs.k8s.io/ d' | sed -e "s/Release notes for/Release notes for ${CIRCLE_TAG}/g" | sed -e "s/Changelog since/Changelog since ${LATEST_RELEASE}/g"> ./build/_output/docs/relnote_parsed.md
@@ -16,4 +18,4 @@ mv ./build/_output/docs/relnote_parsed.md ./build/_output/docs/relnote.md
 make build && make build-mac
 mv  ./build/_output/bin/rotatorctl ./build/_output/bin/rotatorctl-linux
 hub release create -d -a ./build/_output/bin/rotatorctl-linux -a ./build/_output/bin/rotatorctl-darwin --file ./build/_output/docs/relnote.md ${CIRCLE_TAG}
-rm -rf ./build/_output/bin/rotatorctl-linux ./build/_output/bin/rotatorctl-darwin ./build/_output/docs/relnote.md
+rm -rf ./build/_output/


### PR DESCRIPTION
#### Summary
Fix: Pre-create some dirs needed on release



#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Fix: Pre-create directory needed on release
```