### PR TITLE
Fix: Add mod param to avoid dependencies failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,13 +45,13 @@ tests: ## Run go test against code
 .PHONY: build
 build:
 	@echo Building Mattermost Rotatorctl for Linux
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -gcflags all=-trimpath=$(PWD) -asmflags all=-trimpath=$(PWD) -a -installsuffix cgo -o build/_output/bin/$(APP)  ./cmd/$(APP)
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -gcflags all=-trimpath=$(PWD) -asmflags all=-trimpath=$(PWD) -a -installsuffix cgo -mod=mod -o build/_output/bin/$(APP)  ./cmd/$(APP)
 
 # Build for MacOS distribution
 .PHONY: build-mac
 build-mac:
 	@echo Building Mattermost Rotatorctl for Mac
-	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 $(GO) build -gcflags all=-trimpath=$(PWD) -asmflags all=-trimpath=$(PWD) -a -installsuffix cgo -o build/_output/bin/$(APP)-darwin  ./cmd/$(APP)
+	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 $(GO) build -gcflags all=-trimpath=$(PWD) -asmflags all=-trimpath=$(PWD) -a -installsuffix cgo -mod=mod -o build/_output/bin/$(APP)-darwin  ./cmd/$(APP)
 
 # Builds the docker image
 .PHONY: build-image

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -2,6 +2,9 @@
 
 # Usage: sh notify.sh
 
+# Stop script on first error
+set -e
+
 REPO=$(echo $GITHUB_CONTEXT | jq -r '.repository')
 TAGVERSION=$(echo $GITHUB_CONTEXT | jq -r '.event.release.tag_name')
 TAGURL=$(echo $GITHUB_CONTEXT | jq -r '.event.release.html_url')

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,6 +3,9 @@
 # Usage: sh release.sh
 # Note: To run this script locally you need to export environment variables CIRCLE_TAG and GITHUB_TOKEN.
 
+# Stop script on first error
+set -e
+
 FUTURE_RELEASE_SHA=$(hub rev-parse HEAD)
 LATEST_RELEASE=$(hub release)
 LATEST_RELEASE_SHA=$(hub rev-parse ${LATEST_RELEASE})


### PR DESCRIPTION
#### Summary
Fix: Add mod param to avoid dependencies failures

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Fix: Add mod param to avoid dependencies failures
```