### PR TITLE
Change flag on hub release create

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -20,5 +20,9 @@ mv ./build/_output/docs/relnote_parsed.md ./build/_output/docs/relnote.md
 
 make build && make build-mac
 mv  ./build/_output/bin/rotatorctl ./build/_output/bin/rotatorctl-linux
-hub release create -d -a ./build/_output/bin/rotatorctl-linux -a ./build/_output/bin/rotatorctl-darwin --file ./build/_output/docs/relnote.md ${CIRCLE_TAG}
+echo "Debugging lines."
+pwd
+ls -lah ./build/_output/docs/
+ls -lah ./build/_output/bin/
+hub release create -d -F ./build/_output/docs/relnote.md -a ./build/_output/bin/rotatorctl-linux -a ./build/_output/bin/rotatorctl-darwin ${CIRCLE_TAG}
 rm -rf ./build/_output/


### PR DESCRIPTION

#### Summary
Change flag on hub release create.
Add debugging lines to ensure that files exist and we are on the correct directory

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Change flag on hub release create.
Add debugging lines to ensure that files exist and we are on the correct directory.
```