### PR TITLE
Add forgotten notify action on Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .vscode
+*.sw*
 build/_output/
 vendor/
 bin/*

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,12 @@ release:
 	@echo Cut a release
 	sh ./scripts/release.sh
 
+# Notify a release publish
+.PHONY: notify
+notify:
+	@echo Notify a release publish
+	sh ./scripts/notify.sh
+
 .PHONY: tidy
 tidy:
 	@echo Go mod tidy


### PR DESCRIPTION
#### Summary
Add forgotten notify action on Makefile

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add forgotten notify action on Makefile
```